### PR TITLE
Pass RPC instance to handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Make the server listen on a key pair, defaulting to `rpc.defaultKeyPair`. To con
 
 #### `server.respond(method[, options], handler)`
 
-Register a handler for an RPC method. The handler has the signature `handler(request, remoteKey)` and must either return the response value or throw an error.
+Register a handler for an RPC method. The handler has the signature `handler(request, rpc)` and must either return the response value or throw an error. `rpc` is a [`ProtomuxRPC`](https://github.com/holepunchto/protomux-rpc#api) instance.
 
 Only a single handler may be active for any given method; any previous handler is overwritten when registering a new one.
 

--- a/index.js
+++ b/index.js
@@ -266,5 +266,5 @@ class Server extends EventEmitter {
 }
 
 function wrap (handler, rpc) {
-  return (request) => handler(request, rpc.stream.remotePublicKey)
+  return (request) => handler(request, rpc)
 }

--- a/test.mjs
+++ b/test.mjs
@@ -58,8 +58,8 @@ test('remote key', async (t) => {
   const server = rpc.createServer()
   await server.listen()
 
-  server.respond('echo', (req, remoteKey) => {
-    t.alike(remoteKey, keyPair.publicKey)
+  server.respond('echo', (req, rpc) => {
+    t.alike(rpc.stream.remotePublicKey, keyPair.publicKey)
     return req
   })
 


### PR DESCRIPTION
This PR changes the RPC server's `_onconnection` method so that the `stream.remotePublicKey` is passed from hyperswarm to the handler function.