### PR TITLE
Handle stream errors internally + delete unneeded keepAlives

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ class Client extends EventEmitter {
   }
 
   get closed () {
-    return this._closed || this._rpc.closed
+    return this._closed || !this._rpc || this._rpc.closed
   }
 
   get mux () {

--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ class Client extends EventEmitter {
     this._capability = options.capability || null
 
     this._stream = this._dht.connect(publicKey, options)
-    this._stream.on('error', noop) // Errors are implicitly handled internally, with the retries
+    this._stream.on('error', noop)
 
     this._rpc = null
     this._closed = false
@@ -311,7 +311,7 @@ class Server extends EventEmitter {
   }
 
   _onconnection (stream) {
-    stream.on('error', noop) // Errors are handled implicitly by the client, who will retry as needed
+    stream.on('error', noop)
 
     const rpc = new ProtomuxRPC(stream, {
       id: this.publicKey,

--- a/index.js
+++ b/index.js
@@ -184,7 +184,8 @@ class Client extends EventEmitter {
     this._capability = options.capability || null
 
     this._stream = this._dht.connect(publicKey, options)
-    this._stream.setKeepAlive(5000)
+    this._stream.on('error', noop) // Errors are implicitly handled internally, with the retries
+
     this._rpc = null
     this._closed = false
 
@@ -310,6 +311,8 @@ class Server extends EventEmitter {
   }
 
   _onconnection (stream) {
+    stream.on('error', noop) // Errors are handled implicitly by the client, who will retry as needed
+
     const rpc = new ProtomuxRPC(stream, {
       id: this.publicKey,
       valueEncoding: this._defaultValueEncoding,
@@ -319,7 +322,6 @@ class Server extends EventEmitter {
 
     // For Hypercore replication
     stream.userData = rpc.mux
-    stream.setKeepAlive(5000)
 
     this._connections.add(rpc)
     rpc.on('open', (handshake) => {
@@ -396,3 +398,5 @@ class Server extends EventEmitter {
 function wrap (handler, rpc) {
   return (request) => handler(request, rpc)
 }
+
+function noop () {}


### PR DESCRIPTION
hyperdht now sets a default 5000ms keepAlive, so there's no need to set them explicitly